### PR TITLE
resource :answer does not need :question_id 

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -1,6 +1,6 @@
 class AnswersController < ApplicationController
-  before_action :load_question
   before_action :load_answer, only: [:show, :edit, :update, :destroy]
+  before_action :load_question, only: [:index, :new, :create, :destroy]
 
   def index
     @answers = @question.answers
@@ -40,10 +40,12 @@ class AnswersController < ApplicationController
 
   private
   def load_question
-    @question = Question.find(params[:question_id])
+    # answer#destroy is called without question_id when nested resource :answer is defined as shallow
+    # but we need @question to redirect_to after #destroy
+    @question = Question.find( params.fetch(:question_id) { @answer.question_id } )
   end
   def load_answer
-    @answer = @question.answers.find(params[:id])
+    @answer = Answer.find(params[:id])
   end
   def answer_params
     params.require(:answer).permit(:title, :body, :question_id, :user_id)

--- a/spec/controllers/answers_controller_spec.rb
+++ b/spec/controllers/answers_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe AnswersController, type: :controller do
   end
 
   describe 'GET #show' do
-    before { get :show, id: answer, question_id: question }
+    before { get :show, id: answer }
 
     it 'assigns the requested answer to @answer' do
       expect(assigns(:answer)).to eq answer
@@ -41,7 +41,7 @@ RSpec.describe AnswersController, type: :controller do
   end
 
   describe 'GET #edit' do
-    before { get :edit, id: answer, question_id: question }
+    before { get :edit, id: answer }
 
     it 'assigns the requested answer to @answer' do
       expect(assigns(:answer)).to eq answer
@@ -76,22 +76,22 @@ RSpec.describe AnswersController, type: :controller do
   describe 'PATCH #update' do
     context 'with valid attributes' do
       it 'assigns the requested answer to @answer' do
-        patch :update, id: answer, answer: build_attributes(:answer), question_id: question
+        patch :update, id: answer, answer: build_attributes(:answer)
         expect(assigns(:answer)).to eq answer
       end
       it 'changes answer attributes' do
-        patch :update, id: answer, answer: { body: 'new body' }, question_id: question
+        patch :update, id: answer, answer: { body: 'new body' }
         answer.reload
         expect(answer.body).to eq 'new body'
       end
       it 'redirects to updated answer' do
-        patch :update, id: answer, answer: { body: 'new body' }, question_id: question
+        patch :update, id: answer, answer: { body: 'new body' }
         answer.reload
         expect(response).to redirect_to answer_path(assigns(:answer))
       end
     end
     context 'with invalid attributes' do
-      before { patch :update, id: answer, answer: { body: nil }, question_id: question }
+      before { patch :update, id: answer, answer: { body: nil } }
       it 'does not change answer attributes' do
         answer.reload
         expect(answer.body).to eq 'MyText'
@@ -105,10 +105,10 @@ RSpec.describe AnswersController, type: :controller do
   describe 'DELETE #destroy' do
     before { answer; question }
     it 'deletes answer' do
-      expect { delete :destroy, id: answer, question_id: question }.to change(Answer, :count).by(-1)
+      expect { delete :destroy, id: answer }.to change(Answer, :count).by(-1)
     end
     it 'redirects to index view' do
-      delete :destroy, id: answer, question_id: question
+      delete :destroy, id: answer
       expect(response).to redirect_to question_answers_path(question)
     end
   end


### PR DESCRIPTION
resource :answer does not need :question_id 
for all methods when it is defined as shallow