### PR TITLE
lesson 16: advanced rspec, shared examples

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 require: rubocop-rspec
 
 AllCops:
+  RunRailsCops: true
   Exclude:
     - 'bin/**/*'
     - 'config/**/*'
@@ -15,6 +16,14 @@ AllCops:
     - Guardfile
     - Gemfile
   DisplayCopNames: true
+
+Metrics/AbcSize:
+  Exclude:
+    - app/models/ability.rb
+
+Metrics/MethodLength:
+  Exclude:
+    - app/models/ability.rb
 
 Metrics/LineLength:
   Max: 98
@@ -32,4 +41,9 @@ Style/UnneededPercentQ:
   Enabled: false
 
 RSpec/DescribedClass:
+  Enabled: false
+
+# "The first argument to describe should be the class or module being tested"
+# NOT for spec/api
+RSpec/DescribeClass:
   Enabled: false

--- a/app/controllers/api/v1/answers_controller.rb
+++ b/app/controllers/api/v1/answers_controller.rb
@@ -1,26 +1,30 @@
-class API::V1::AnswersController < API::V1::BaseController
-  before_action :load_resource, only: :show
-  before_action :load_question, only: [:index, :show, :create]
+module API
+  module V1
+    class AnswersController < API::V1::BaseController
+      before_action :load_resource, only: :show
+      before_action :load_question, only: [:index, :show, :create]
 
-  def index
-    respond_with(@answers = @question.answers)
-  end
+      def index
+        respond_with(@answers = @question.answers)
+      end
 
-  def show
-    respond_with @answer
-  end
+      def show
+        respond_with @answer
+      end
 
-  def create
-    respond_with(@answer = @question.answers.create(resource_params))
-  end
+      def create
+        respond_with(@answer = @question.answers.create(resource_params))
+      end
 
-  private
+      private
 
-  def load_question
-    @question = Question.find(params[:question_id])
-  end
+      def load_question
+        @question = Question.find(params[:question_id])
+      end
 
-  def permit_attributes
-    [:body]
+      def permit_attributes
+        [:body]
+      end
+    end
   end
 end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,13 +1,17 @@
-class API::V1::BaseController < ApplicationThinController
-  before_action :doorkeeper_authorize!
+module API
+  module V1
+    class BaseController < ApplicationThinController
+      before_action :doorkeeper_authorize!
 
-  skip_authorization_check
+      skip_authorization_check
 
-  respond_to :json
+      respond_to :json
 
-  protected
+      protected
 
-  def current_user
-    @current_user ||= User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
+      def current_user
+        @current_user ||= User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
+      end
+    end
   end
 end

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,9 +1,13 @@
-class API::V1::ProfilesController < API::V1::BaseController
-  def index
-    respond_with User.all_except current_user
-  end
+module API
+  module V1
+    class ProfilesController < API::V1::BaseController
+      def index
+        respond_with User.all_except current_user
+      end
 
-  def me
-    respond_with current_user
+      def me
+        respond_with current_user
+      end
+    end
   end
 end

--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -1,21 +1,25 @@
-class API::V1::QuestionsController < API::V1::BaseController
-  before_action :load_resource, only: :show
+module API
+  module V1
+    class QuestionsController < API::V1::BaseController
+      before_action :load_resource, only: :show
 
-  def index
-    respond_with(@questions = Question.all)
-  end
+      def index
+        respond_with(@questions = Question.all)
+      end
 
-  def show
-    respond_with @question
-  end
+      def show
+        respond_with @question
+      end
 
-  def create
-    respond_with(@question = Question.create(resource_params))
-  end
+      def create
+        respond_with(@question = Question.create(resource_params))
+      end
 
-  private
+      private
 
-  def permit_attributes
-    [:title, :body]
+      def permit_attributes
+        [:title, :body]
+      end
+    end
   end
 end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -6,8 +6,4 @@ class Attachment < ActiveRecord::Base
   validates :file, presence: true
 
   mount_uploader :file, FileUploader
-
-  def url
-    file.url
-  end
 end

--- a/app/models/concerns/votable.rb
+++ b/app/models/concerns/votable.rb
@@ -18,10 +18,12 @@ module Votable
 
   def new_vote_by(user, like = LIKE)
     votes.create(user: user, like: like)
+    self
   end
 
   def withdraw_vote_by(user)
     votes.where(user: user).delete_all
+    self
   end
 
   def voted_by?(user)

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -1,8 +1,8 @@
 class Identity < ActiveRecord::Base
   belongs_to :user
 
-  validates_presence_of :uid, :provider
-  validates_uniqueness_of :uid, scope: :provider
+  validates :uid, :provider, presence: true
+  validates :uid, uniqueness: { scope: :provider }
 
   def self.find_or_create_for_auth(auth)
     find_or_create_by(provider: auth.provider, uid: auth.uid.to_s)

--- a/app/serializers/attachment_serializer.rb
+++ b/app/serializers/attachment_serializer.rb
@@ -1,3 +1,7 @@
 class AttachmentSerializer < ActiveModel::Serializer
   attributes :url
+
+  def url
+    object.file.url
+  end
 end

--- a/app/views/comments/create.js.erb
+++ b/app/views/comments/create.js.erb
@@ -4,7 +4,5 @@
 } do %>
   $("#form_new_comment_for_<%= dom_id @commentable %>").hide()
   $("#link_new_comment_for_<%= dom_id @commentable %>").show()
-  <% publish_to "/comments" do %>
-    $("#comments_<%= dom_id @commentable %>").append('<%= j render 'comments/comment', comment: @comment %>');
-  <% end %>
+  //
 <% end %>

--- a/spec/api/v1/answers_spec.rb
+++ b/spec/api/v1/answers_spec.rb
@@ -2,80 +2,81 @@ require 'rails_helper'
 
 RSpec.describe 'Answers API' do
   describe 'GET #index' do
-    context 'unauthorized' do
-      let!(:question) { create :question }
+    let!(:question) { create :question }
+    let(:api_path) { api_v1_question_answers_path(question) }
 
-      it 'returns status unauthorized if access_token is not provided' do
-        get api_v1_question_answers_path(question), format: :json
-        expect(response).to be_unauthorized
-      end
-
-      it 'returns status unauthorized if access_token is invalid' do
-        get api_v1_question_answers_path(question), format: :json, access_token: SecureRandom.hex
-        expect(response).to be_unauthorized
-      end
-    end
+    it_behaves_like "API authenticatable"
 
     context 'authorized' do
-      let(:path_resource) { "answers/0" }
       let(:access_token) { create :access_token }
       let(:question) { create :question }
       let(:answer) { create(:answer, :with_files, files_count: 3, question: question) }
       let(:answer2) { create :answer, question: question }
       let!(:answers) { [answer, answer2] }
-      let!(:comments) { create_list :comment, 3, commentable: resource }
-      let!(:resource) { answer }
-      let!(:attachments) { resource.attachments }
+      let!(:comments) { create_list :comment, 2, commentable: answer }
+      let!(:attachments) { answer.attachments }
 
       let(:attributes) { attributes_for :answer }
-      let(:params) { { answer: attributes, format: :json, access_token: access_token.token } }
+      let(:token) { access_token.token }
+      let(:params) { { answer: attributes, format: :json, access_token: token } }
       let(:post_create) { post api_v1_question_answers_path(question), params }
 
       before do
-        get api_v1_question_answers_path(question), format: :json, access_token: access_token.token
+        get api_v1_question_answers_path(question), format: :json, access_token: token
       end
 
-      it 'returns status ok' do
-        expect(response).to be_success
-      end
+      it_behaves_like "response ok"
 
       it 'returns list of answers' do
         expect(response.body).to have_json_size(answers.size).at_path("answers")
       end
 
-      resource_attributes(:answer).each do |attr|
+      permitted_attributes = [
+        :id, :body, :user_id, :created_at, :updated_at
+      ]
+      permitted_attributes.each do |attr|
         it "contains #{ attr }" do
-          resource_attr = resource.send(attr.to_sym).to_json
-          path = "#{ path_resource }/#{ attr }"
-          expect(response.body).to be_json_eql(resource_attr).at_path(path)
+          answer_attr = answer.send(attr.to_sym).to_json
+          path = "answers/0/#{ attr }"
+          expect(response.body).to be_json_eql(answer_attr).at_path(path)
         end
       end
 
-      resource_associations(:answer).each do |association|
-        context "#{ association }" do
-          it "includes #{ association }" do
-            path = "#{ path_resource }/#{ association }"
-            expect(response.body).to have_json_size(resource.send(association).count).at_path(path)
-          end
+      context "nested comments" do
+        it "includes comments" do
+          path = "answers/0/comments"
+          expect(response.body).to have_json_size(answer.comments.size).at_path(path)
+        end
 
-          resource_attributes(association).each do |attr|
-            it "#{ association.to_s.singularize } contains #{ attr }" do
-              path = "#{ path_resource }/#{ association }/0/#{ attr }"
-              association_attr = send(association).first.send(attr.to_sym).to_json
-              expect(response.body).to be_json_eql(association_attr).at_path(path)
-            end
+        permitted_attributes = [
+          :id, :body, :user_id, :created_at, :updated_at
+        ]
+        permitted_attributes.each do |attr|
+          it "comment contains #{ attr }" do
+            path = "answers/0/comments/0/#{ attr }"
+            comment_attr = comments.first.send(attr.to_sym).to_json
+            expect(response.body).to be_json_eql(comment_attr).at_path(path)
           end
+        end
+      end
+
+      context "nested attachments" do
+        it "includes attachments" do
+          path = "answers/0/attachments"
+          expect(response.body).to have_json_size(attachments.size).at_path(path)
+        end
+
+        it "attachment contains url" do
+          path = "answers/0/attachments/0/url"
+          expect(response.body).to be_json_eql(attachments.first.file.url.to_json).at_path(path)
         end
       end
 
       context 'create new answer' do
-        it 'returns status created' do
-          post_create
-          expect(response).to be_created
-        end
+        it_behaves_like "creatable"
 
         it 'saves new answer in db' do
-          expect { post_create }.to change { question.answers.count }.by(1)
+          expect { post_create }.to change { question.answers.size }.by(1)
         end
       end
     end

--- a/spec/api/v1/profiles_spec.rb
+++ b/spec/api/v1/profiles_spec.rb
@@ -2,17 +2,9 @@ require 'rails_helper'
 
 RSpec.describe 'Profile API' do
   describe 'GET #index' do
-    context 'unauthorized' do
-      it 'returns status unauthorized if access_token is not provided' do
-        get '/api/v1/profiles/', format: :json
-        expect(response).to be_unauthorized
-      end
+    let(:api_path) { api_v1_profiles_path }
 
-      it 'returns status unauthorized if access_token is invalid' do
-        get '/api/v1/profiles/', format: :json, access_token: SecureRandom.hex
-        expect(response).to be_unauthorized
-      end
-    end
+    it_behaves_like "API authenticatable"
 
     context 'authorized' do
       let!(:me) { create :user }
@@ -21,9 +13,7 @@ RSpec.describe 'Profile API' do
 
       before { get '/api/v1/profiles/', format: :json, access_token: access_token.token }
 
-      it 'returns status ok' do
-        expect(response).to be_success
-      end
+      it_behaves_like "response ok"
 
       it 'returns list of users except resource owner' do
         expect(response.body).to have_json_size(users.size).at_path('profiles')
@@ -33,17 +23,9 @@ RSpec.describe 'Profile API' do
   end
 
   describe 'GET #me' do
-    context 'unauthorized' do
-      it 'returns status unauthorized if access_token is not provided' do
-        get '/api/v1/profiles/me', format: :json
-        expect(response).to be_unauthorized
-      end
+    let(:api_path) { me_api_v1_profiles_path }
 
-      it 'returns status unauthorized if access_token is invalid' do
-        get '/api/v1/profiles/me', format: :json, access_token: SecureRandom.hex
-        expect(response).to be_unauthorized
-      end
-    end
+    it_behaves_like "API authenticatable"
 
     context 'authorized' do
       let(:me) { create :user }
@@ -51,9 +33,7 @@ RSpec.describe 'Profile API' do
 
       before { get '/api/v1/profiles/me', format: :json, access_token: access_token.token }
 
-      it 'returns status ok' do
-        expect(response).to be_success
-      end
+      it_behaves_like "response ok"
 
       %w(id email created_at updated_at admin).each do |attr|
         it "contains #{ attr }" do

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe AttachmentsController, type: :controller do
-  let!(:question) { create(:question, :with_files, files_count: 1) }
+  let!(:question) { create :question, :with_files, files_count: 1 }
   let(:files) { question.attachments }
-  let(:user) { create(:user) }
+  let(:user) { create :user }
   let(:delete_file) { delete :destroy, id: files.first, format: :js }
 
   describe 'DELETE #destroy' do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe Ability, type: :model do
     let(:other_comment) { create :comment }
     let(:his_attachment) { create :attachment, attachable: his_question }
     let(:other_attachment) { create :attachment, attachable: other_question }
-    let(:voted_question) { other_question.liked_by user; other_question }
-    let(:voted_answer) { other_answer.liked_by user; other_answer }
+    let(:voted_question) { other_question.liked_by(user) }
+    let(:voted_answer) { other_answer.liked_by(user) }
 
     it { should_not be_able_to :manage, :all }
     it { should be_able_to :read, :all }

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 RSpec.describe Answer, type: :model do
   it { should validate_presence_of :body }
   it { should validate_presence_of :question }
-  it { should validate_presence_of :user }
+
+  it_behaves_like "authorable"
+  it_behaves_like "commentable"
+  it_behaves_like "attachable"
+  it_behaves_like "votable"
 
   it { should belong_to(:question) }
-  it { should have_many(:attachments).dependent(:destroy) }
-  it { should have_many(:comments).dependent(:destroy) }
-
-  it { should accept_nested_attributes_for :attachments }
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -3,5 +3,6 @@ require 'rails_helper'
 RSpec.describe Comment, type: :model do
   it { should belong_to :commentable }
   it { should validate_presence_of :body }
-  it { should validate_presence_of :user }
+
+  it_behaves_like "authorable"
 end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -3,12 +3,11 @@ require 'rails_helper'
 RSpec.describe Question, type: :model do
   it { should validate_presence_of :title }
   it { should validate_presence_of :body }
-  it { should validate_presence_of :user }
+
+  it_behaves_like "authorable"
+  it_behaves_like "commentable"
+  it_behaves_like "attachable"
+  it_behaves_like "votable"
 
   it { should have_many(:answers).dependent(:destroy) }
-  it { should have_many(:attachments).dependent(:destroy) }
-  it { should have_many(:votes).dependent(:destroy) }
-  it { should have_many(:comments).dependent(:destroy) }
-
-  it { should accept_nested_attributes_for :attachments }
 end

--- a/spec/models/vote_spec.rb
+++ b/spec/models/vote_spec.rb
@@ -2,79 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Vote, type: :model do
   it { should belong_to :votable }
-  it { should belong_to :user }
-  it { should validate_presence_of :user }
   it { should validate_presence_of :like }
   it { should validate_inclusion_of(:like).in_array [Votable::LIKE, Votable::DISLIKE] }
 
-  let(:users)      { create_list(:user, 2) }
-  let(:user)       { users.at(0) }
-  let(:other_user) { users.at(1) }
-  let(:question)   { create(:question) }
-  let(:answer)     { create(:answer, question: question) }
-
-  models_with_association(:votable).each do |votable_name|
-    describe "vote for #{votable_name}" do
-      let(:votable) { send votable_name }
-
-      it "like by user" do
-        expect { votable.liked_by user }.to change { votable.votes.count }.by(1)
-        expect(votable.voted_by? user).to be true
-        expect(votable.vote_by user).to eq Votable::LIKE
-      end
-
-      it "dislike by user" do
-        expect { votable.disliked_by user }.to change { votable.votes.count }.by(1)
-        expect(votable.voted_by? user).to be true
-        expect(votable.vote_by user).to eq Votable::DISLIKE
-      end
-
-      it "only one vote is accepted from user for any given #{votable_name}" do
-        votable.liked_by user
-        expect { votable.liked_by user }.to_not change { votable.votes.count }
-        expect { votable.disliked_by user }.to_not change { votable.votes.count }
-      end
-
-      it "change vote (withdraw previous vote first, then vote again)" do
-        votable.liked_by user
-        votable.withdraw_vote_by user
-        expect { votable.disliked_by user }.to change { votable.votes.count }.by(1)
-        expect(votable.voted_by? user).to be true
-      end
-    end
-
-    describe "#{ votable_name } rating" do
-      let(:votable) { send votable_name }
-
-      it "#{ votable_name } rating is 0 by default" do
-        expect(votable.rating).to eq 0
-      end
-
-      it "like by user increase #{ votable_name } rating" do
-        expect { votable.liked_by user }.to change { votable.rating }.by(1)
-      end
-
-      it 'likes by different users increase question rating' do
-        votable.liked_by user
-        votable.liked_by other_user
-        expect(votable.rating).to eq 2
-      end
-
-      it "subsequent votes by same user do not change #{ votable_name } rating" do
-        votable.liked_by user
-        expect { votable.liked_by user }.to_not change { votable.rating }
-      end
-
-      it "#{ votable_name } rating is changed when user withdraw his vote" do
-        votable.liked_by user
-        expect { votable.withdraw_vote_by user }.to change { votable.rating }.by(-1)
-      end
-
-      it "#{ votable_name } rating is changed when user change his vote" do
-        votable.liked_by user
-        votable.withdraw_vote_by user
-        expect { votable.disliked_by user }.to change { votable.rating }.by(-1)
-      end
-    end
-  end
+  it_behaves_like "authorable"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -98,15 +98,3 @@ def models_with_association association_polymorphic_name
   Rails.application.eager_load!
   ActiveRecord::Base.send(:subclasses).select{ |model| model.reflect_on_all_associations.map { |assoc| assoc.options[:as] == association_polymorphic_name }.any? }.map{ |model| model.name.underscore } 
 end
-
-def resource_attributes(resource)
-  resource_serializer(resource)._attributes
-end
-
-def resource_associations(resource)
-  resource_serializer(resource)._associations.keys
-end
-
-def resource_serializer(resource)
-  "#{ resource.to_s.singularize.capitalize }Serializer".classify.constantize
-end

--- a/spec/support/shared/api_authorization.rb
+++ b/spec/support/shared/api_authorization.rb
@@ -1,0 +1,27 @@
+shared_examples_for "API authenticatable" do
+  context 'unauthorized' do
+    it 'returns status 401 :unauthorized, if access_token is not provided' do
+      get api_path, format: :json
+      expect(response).to be_unauthorized
+    end
+
+    it 'returns status 401 :unauthorized, if access_token is invalid' do
+      get api_path, format: :json, access_token: SecureRandom.hex
+      expect(response).to be_unauthorized
+    end
+  end
+end
+
+# OMG, "successfuly responsable"?! No, thanks
+shared_examples_for "response ok" do
+  it 'returns status 200 :ok' do
+    expect(response).to be_success
+  end
+end
+
+shared_examples_for "creatable" do
+  it 'returns status 201 :created' do
+    post_create
+    expect(response).to be_created
+  end
+end

--- a/spec/support/shared/attachable.rb
+++ b/spec/support/shared/attachable.rb
@@ -1,0 +1,4 @@
+shared_examples_for "attachable" do
+  it { should have_many(:attachments).dependent(:destroy) }
+  it { should accept_nested_attributes_for :attachments }
+end

--- a/spec/support/shared/authorable.rb
+++ b/spec/support/shared/authorable.rb
@@ -1,0 +1,4 @@
+shared_examples_for "authorable" do
+  it { should belong_to :user }
+  it { should validate_presence_of :user }
+end

--- a/spec/support/shared/commentable.rb
+++ b/spec/support/shared/commentable.rb
@@ -1,0 +1,3 @@
+shared_examples_for "commentable" do
+  it { should have_many(:comments).dependent(:destroy) }
+end

--- a/spec/support/shared/publishable.rb
+++ b/spec/support/shared/publishable.rb
@@ -1,0 +1,18 @@
+shared_examples_for "publishable" do
+  # requires do_request
+  # requires publish_channel
+
+  it "publishes to given channel for subscribers" do
+    expect(PrivatePub).to receive(:publish_to).with(publish_channel, anything)
+    do_request
+  end
+end
+
+shared_examples_for "not publishable" do
+  # requires do_request
+
+  it "does not publish anything" do
+    expect(PrivatePub).to_not receive(:publish_to)
+    do_request
+  end
+end

--- a/spec/support/shared/votable.rb
+++ b/spec/support/shared/votable.rb
@@ -1,0 +1,71 @@
+shared_examples_for "votable" do
+  # requires votable
+
+  it { should have_many(:votes).dependent(:destroy) }
+
+  describe "votable" do
+    let(:votable) { create subject.model_name.element }
+    let(:users)      { create_list(:user, 2) }
+    let(:user)       { users.at(0) }
+    let(:other_user) { users.at(1) }
+
+    context "voting" do
+      it "like by user" do
+        expect { votable.liked_by user }.to change { votable.votes.count }.by(1)
+        expect(votable.voted_by? user).to be true
+        expect(votable.vote_by user).to eq Votable::LIKE
+      end
+
+      it "dislike by user" do
+        expect { votable.disliked_by user }.to change { votable.votes.count }.by(1)
+        expect(votable.voted_by? user).to be true
+        expect(votable.vote_by user).to eq Votable::DISLIKE
+      end
+
+      it "accept only one vote from given user for given votable resource" do
+        votable.liked_by user
+        expect { votable.liked_by user }.to_not change { votable.votes.count }
+        expect { votable.disliked_by user }.to_not change { votable.votes.count }
+      end
+
+      it "can be changed later (user withdraw previous vote first, then vote again)" do
+        votable.liked_by user
+        votable.withdraw_vote_by user
+        expect { votable.disliked_by user }.to change { votable.votes.count }.by(1)
+        expect(votable.voted_by? user).to be true
+      end
+    end
+
+    context "rating" do
+      it "is 0 by default" do
+        expect(votable.rating).to eq 0
+      end
+
+      it "increases after like by user" do
+        expect { votable.liked_by user }.to change { votable.rating }.by(1)
+      end
+
+      it 'increases after likes by different users' do
+        votable.liked_by user
+        votable.liked_by other_user
+        expect(votable.rating).to eq 2
+      end
+
+      it "does not change after subsequent votes by same user" do
+        votable.liked_by user
+        expect { votable.liked_by user }.to_not change { votable.rating }
+      end
+
+      it "is changed when user withdraws his vote" do
+        votable.liked_by user
+        expect { votable.withdraw_vote_by user }.to change { votable.rating }.by(-1)
+      end
+
+      it "is changed when user changes his vote" do
+        votable.liked_by user
+        votable.withdraw_vote_by user
+        expect { votable.disliked_by user }.to change { votable.rating }.by(-1)
+      end
+    end
+  end
+end

--- a/spec/support/shared/votable_action_unauthorized.rb
+++ b/spec/support/shared/votable_action_unauthorized.rb
@@ -1,0 +1,15 @@
+shared_examples_for "votable action unauthorized" do
+  # requires votable
+  # requires do_request
+
+  before { sign_in votable.author }
+
+  it "does not change rating" do
+    expect { do_request }.to_not change { votable.reload.rating }
+  end
+
+  it "renders status forbidden" do
+    do_request
+    expect(response).to be_forbidden
+  end
+end

--- a/spec/support/shared/votable_controller.rb
+++ b/spec/support/shared/votable_controller.rb
@@ -1,0 +1,80 @@
+shared_examples_for "Votable Controller" do
+  # requires votable
+
+  let(:user) { create :user }
+  let(:patch_like) { patch :like, id: votable, format: :js }
+  let(:patch_dislike) { patch :dislike, id: votable, format: :js }
+  let(:patch_withdraw_vote) { patch :withdraw_vote, id: votable, format: :js }
+
+  describe "PATCH #like" do
+    let(:do_request) { patch_like }
+
+    context "when authorized" do
+      before { sign_in user }
+
+      it "increase rating" do
+        expect { patch_like }.to change { votable.reload.rating }.by(1)
+      end
+
+      it "renders partial votes/update" do
+        patch_like
+        expect(response).to render_template 'votes/update'
+      end
+    end
+
+    context "when unauthorized" do
+      it_behaves_like "votable action unauthorized"
+    end
+  end
+
+  describe "PATCH #dislike" do
+    let(:do_request) { patch_dislike }
+
+    context "when authorized" do
+      before { sign_in user }
+
+      it "decrease rating" do
+        expect { patch_dislike }.to change { votable.reload.rating }.by(-1)
+      end
+
+      it "renders partial votes/update" do
+        patch_dislike
+        expect(response).to render_template 'votes/update'
+      end
+    end
+
+    context "when unauthorized" do
+      it_behaves_like "votable action unauthorized"
+    end
+  end
+
+  describe "PATCH #withdraw_vote" do
+    let(:do_request) { patch_withdraw_vote }
+
+    context "when authorized" do
+      before { sign_in user }
+
+      it "returns rating back to zero" do
+        patch_like
+        patch_withdraw_vote
+        expect(votable.reload.rating).to eq 0
+      end
+
+      it "does not change rating after second and subsequent calls" do
+        patch_like
+        patch_withdraw_vote
+        expect { patch_withdraw_vote }.to_not change { votable.reload.rating }
+      end
+
+      it "renders partial votes/update" do
+        patch_like
+        patch_withdraw_vote
+        expect(response).to render_template 'votes/update'
+      end
+    end
+
+    context "when unauthorized" do
+      it_behaves_like "votable action unauthorized"
+    end
+  end
+end


### PR DESCRIPTION
Исправил замечания по предыдущему заданию

* убрал декоратор "url" из модели (перенес в сериалайзер)
* разбавил "слишком сухие" (overDRY) тесты API

Вернул обязательную авторизацию для методов в API контроллерах (authorize_resource)
Вынес повторяющиеся блоки в shared examples для моделей, контроллеров и API
Добавил тесты для вызовов PrivatePub.publish_to в контроллерах

Репутацию пока не стал добавлять, потом если время останется погляжу